### PR TITLE
Exclude db config from application properties

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration


### PR DESCRIPTION
Disable the auto-configuration using the `spring.autoconfigure.exclude` property

See https://www.baeldung.com/spring-boot-failed-to-configure-data-source