### PR TITLE
✨ Add unlike button

### DIFF
--- a/src/main/javascript/src/components/show/PageShow/PageShow.tsx
+++ b/src/main/javascript/src/components/show/PageShow/PageShow.tsx
@@ -1,21 +1,39 @@
 import React from 'react';
 import { useParams, useHistory } from 'react-router-dom';
 import {
-  Alert, Button, Col, Collapse, Drawer, PageHeader, Row, Tag, Typography,
+  Alert,
+  Button,
+  Col,
+  Collapse,
+  Drawer,
+  notification,
+  PageHeader,
+  Popconfirm,
+  Row,
+  Tag,
+  Typography,
 } from 'antd';
 
+import { Placeholder } from 'components/ui/Placeholder/Placeholder';
+import { ClickableMark } from 'components/ui/ClickableMark/ClickableMark';
+import { deleteLike } from 'lib/api/likes';
 import { Like } from 'lib/types';
 import { useGetData } from 'lib/hooks';
-import { Placeholder } from 'components/ui/Placeholder/Placeholder';
 import { RoutePath } from 'lib/constants';
 import { parseDate } from 'lib/util';
-import { ClickableMark } from 'components/ui/ClickableMark/ClickableMark';
 
 import './page-show.scss';
 
 const BLOCK = 'show_page-show';
 const { Panel } = Collapse;
 const { Title, Text } = Typography;
+
+const openErrorNotification = () => {
+  notification.error({
+    message: 'Server Error',
+    description: 'Could not unlike this show at the moment. Please retry in a few seconds.',
+  });
+};
 
 export const PageShow: React.FunctionComponent = () => {
   const [isDrawerVisible, setIsDrawerVisible] = React.useState(false);
@@ -71,7 +89,21 @@ export const PageShow: React.FunctionComponent = () => {
                 <Text>{`${show.next_episode_to_air.season_number}x${show.next_episode_to_air.episode_number}, ${show.next_episode_to_air.name}, airs on: ${parseDate(show.next_episode_to_air.air_date).toLocaleDateString()}`}</Text>
               </div>
             )}
-            <div className={`${BLOCK}__open-panel`}><Button onClick={() => setIsDrawerVisible(true)}>See details</Button></div>
+            <div className={`${BLOCK}__bottom-buttons`}>
+              <Popconfirm
+                title="Are you sure you want to unlike this show?"
+                onConfirm={() => {
+                  deleteLike(show.id)
+                    .then(() => replace(RoutePath.shows))
+                    .catch(openErrorNotification);
+                }}
+                okText="Yes"
+                cancelText="No"
+              >
+                <Button icon="delete" type="danger">Unlike</Button>
+              </Popconfirm>
+              <Button onClick={() => setIsDrawerVisible(true)}>See details</Button>
+            </div>
           </Col>
         </Row>
       </div>

--- a/src/main/javascript/src/components/show/PageShow/page-show.scss
+++ b/src/main/javascript/src/components/show/PageShow/page-show.scss
@@ -11,8 +11,12 @@
     background-color: rgba(255, 255, 255, 0.6);
     padding: $spacing-md;
   }
-  &__open-panel {
+  &__bottom-buttons {
+    margin-top: $spacing-lg;
     display: flex;
     justify-content: right;
+    & > * {
+      margin: 0 $spacing-xs;
+    }
   }
 }

--- a/src/main/javascript/src/components/ui/ClickableMark/ClickableMark.tsx
+++ b/src/main/javascript/src/components/ui/ClickableMark/ClickableMark.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Icon } from 'antd';
 
-import { putLikes } from 'lib/api/likes';
+import { putLike } from 'lib/api/likes';
 
 import './clickable-mark.scss';
 
@@ -20,7 +20,7 @@ export const ClickableMark: React.FunctionComponent<ClickableMarkProps> = ({ mar
       <Icon
         className={`${BLOCK}__icon`}
         onClick={() => {
-          putLikes(showId, 0).then(res => {
+          putLike(showId, 0).then(res => {
             if (res) {
               setUpdatedMark(0);
             }
@@ -32,7 +32,7 @@ export const ClickableMark: React.FunctionComponent<ClickableMarkProps> = ({ mar
       <Icon
         className={`${BLOCK}__icon`}
         onClick={() => {
-          putLikes(showId, 1).then(res => {
+          putLike(showId, 1).then(res => {
             if (res) {
               setUpdatedMark(1);
             }
@@ -44,7 +44,7 @@ export const ClickableMark: React.FunctionComponent<ClickableMarkProps> = ({ mar
       <Icon
         className={`${BLOCK}__icon`}
         onClick={() => {
-          putLikes(showId, 2).then(res => {
+          putLike(showId, 2).then(res => {
             if (res) {
               setUpdatedMark(2);
             }

--- a/src/main/javascript/src/lib/api/likes.ts
+++ b/src/main/javascript/src/lib/api/likes.ts
@@ -4,6 +4,10 @@ export function postLikes(id: number) {
   return api.post('likes', { json: { show: { id } } });
 }
 
-export function putLikes(id: number, mark: 0 | 1 | 2) {
+export function putLike(id: number, mark: 0 | 1 | 2) {
   return api.put(`likes/${id}`, { json: { mark } });
+}
+
+export function deleteLike(id: number) {
+  return api.delete(`likes/${id}`);
 }


### PR DESCRIPTION
## What does this PR do?
Adds a `unlike` button to the show page that deletes the show from the likes shows and redirect you to the show list.

<img width="553" alt="Image 2019-11-18 at 7 57 47 PM" src="https://user-images.githubusercontent.com/33065180/69081165-b558cd00-0a3d-11ea-98b3-8156718e4792.png">

## Motivation (link to Trello card)
https://trello.com/c/u4yZSeQU

## Testing Guidelines
Hit https://chowchow-ui-staging.herokuapp.com, go to the show page of one your liked shows. You should see the button and be able to confirm the deletion.

## Release Checklist

-   [ ] This code has automated tests
-   [ ] This code has documentation
-   [x] I have a plan to verify that these changes are working as expected after deploy

## Additional Notes
