### PR TITLE
✏ Instructions for javadoc generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,21 @@ The database schema is automatically created by Flyway migrations
 and validated by Hibernate.
 
 ### Setting-up the front-end
-Run the following commands
-```
+Run the following commands to start the development server.
+```$xslt
 cd src/main/javascript
 yarn start
 ```
 You'll be able to test the UI on `localhost:3000`
 
-## API Documentation
-Available when the server is running at `/swagger-ui.html`
+## Project Documentation
+
+### Javadoc
+To generate the Javadoc run:
+```$xslt
+mvn javadoc:javadoc
+```
+The javadoc can the be accessed at `/target/site/apidocs/index.html
+`
+### API documentation
+When ChowChow API is running, you can access the API documentation at `/swagger-ui.html`.


### PR DESCRIPTION
## [Depends on 47](https://github.com/hinosxz/chowchow/pull/47)

## What does this PR do?
It adds instructions to generate and access javadoc

## Motivation (link to Trello card)
https://trello.com/c/8MjvIT79/68-add-javadoc-auto-generation

## Testing Guidelines
Follow the `README.md`
## Release Checklist

-   [ ] This code has automated tests
-   [ ] This code has documentation
-   [x] I have a plan to verify that these changes are working as expected after deploy

## Additional Notes
